### PR TITLE
Compatibility with Ansible 2.9. Updated + new Terraform versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,34 +1,12 @@
 ---
 app:
   name: terraform
-  version: 0.6.8
+  version: 0.12.24
+  file_group: root
+  file_user: root
 
 install:
   dir : /usr/local/bin
   download_location: https://releases.hashicorp.com/terraform
   file_list:
     - terraform
-    - terraform-provider-digitalocean
-    - terraform-provider-null
-    - terraform-provisioner-chef
-    - terraform-provider-atlas
-    - terraform-provider-dme
-    - terraform-provider-openstack
-    - terraform-provisioner-file
-    - terraform-provider-aws
-    - terraform-provider-dnsimple
-    - terraform-provider-packet
-    - terraform-provisioner-local-exec
-    - terraform-provider-azure
-    - terraform-provider-docker
-    - terraform-provider-rundeck
-    - terraform-provisioner-remote-exec
-    - terraform-provider-cloudflare
-    - terraform-provider-google
-    - terraform-provider-template
-    - terraform-provider-cloudstack
-    - terraform-provider-heroku
-    - terraform-provider-terraform
-    - terraform-provider-consul
-    - terraform-provider-mailgun
-    - terraform-provider-vsphere

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,10 @@
     arch: darwin_amd64
   when: ansible_system == 'Darwin'
 
+- set_fact:
+    arch: linux_arm
+  when: ansible_architecture == 'armv7l'
+
 - name: "Downloads Package"
   get_url:
     url: "{{ install.download_location}}/{{ app.version }}/{{ app.name }}_{{ app.version }}_{{ arch }}.zip"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,16 +5,16 @@
 
 - set_fact:
     arch: darwin_amd64
-  when: ansible_system == "Darwin"
+  when: ansible_system == 'Darwin'
 
-- name: Downloads Package
-  get_url: >
-    url="{{ install.download_location}}/{{ app.version }}/{{ app.name }}_{{ app.version }}_{{ arch }}.zip"
-    dest="/tmp/{{ app.name }}_{{ app.version }}_{{ arch }}.zip"
-    mode=0755
-    force={{ install.force_download | default(false)}}
-    validate_certs=no
-  sudo: no
+- name: "Downloads Package"
+  get_url:
+    url: "{{ install.download_location}}/{{ app.version }}/{{ app.name }}_{{ app.version }}_{{ arch }}.zip"
+    dest: "/tmp/{{ app.name }}_{{ app.version }}_{{ arch }}.zip"
+    mode: "0755"
+    force: "{{ install.force_download | default(false)}}"
+    validate_certs: no
+  become: no
   tags:
     - hashicorp
     - terraform
@@ -22,12 +22,12 @@
     - download
 
 - name: Unpacks to location
-  unarchive: >
-    src=/tmp/{{ app.name }}_{{ app.version }}_{{ arch }}.zip
-    dest={{ install.dir }}
-    copy=no
-    mode=755
-  sudo: yes
+  unarchive:
+    src: "/tmp/{{ app.name }}_{{ app.version }}_{{ arch }}.zip"
+    dest: "{{ install.dir }}"
+    copy: no
+    mode: "755"
+  become: yes
   tags:
     - hashicorp
     - terraform
@@ -35,11 +35,12 @@
     - unarchive
 
 - name: Fix permissions on files (Workaround while waiting for 2.0)
-  file: path={{ install.dir }}/{{ item }}
-    owner={{ app.file_owner | default('root') }}
-    group={{ app.file_group | default('staff') }}
-    mode=755
-  sudo: yes
+  file: 
+    path: "{{ install.dir }}/{{ item }}"
+    owner: "{{ app.file_owner | default('root') }}"
+    group: "{{ app.file_group | default('staff') }}"
+    mode: "755"
+  become: yes
   with_items:
     - "{{ install.file_list }}"
   tags:


### PR DESCRIPTION
Compatibility with Ansible 2.9. Updated defaults due to new Terraform version zip, only one binary file